### PR TITLE
Improve fixed splitter buffer-first behavior

### DIFF
--- a/api/core/rag/splitter/fixed_text_splitter.py
+++ b/api/core/rag/splitter/fixed_text_splitter.py
@@ -56,18 +56,42 @@ class FixedRecursiveCharacterTextSplitter(EnhanceRecursiveCharacterTextSplitter)
 
     def split_text(self, text: str) -> list[str]:
         """Split incoming text and return chunks."""
-        if self._fixed_separator:
-            chunks = text.split(self._fixed_separator)
-        else:
-            chunks = [text]
+        if not self._fixed_separator:
+            chunk_length = self._length_function([text])[0] if text else 0
+            if chunk_length <= self._chunk_size:
+                return [text]
 
-        final_chunks = []
-        chunks_lengths = self._length_function(chunks)
-        for chunk, chunk_length in zip(chunks, chunks_lengths):
-            if chunk_length > self._chunk_size:
-                final_chunks.extend(self.recursive_split_text(chunk))
+            return self.recursive_split_text(text)
+
+        splits = text.split(self._fixed_separator)
+
+        if not splits:
+            return []
+
+        final_chunks: list[str] = []
+        current_splits: list[str] = []
+        current_lengths: list[int] = []
+        separator_for_merge = self._fixed_separator if self._keep_separator else ""
+        splits_lengths = self._length_function(splits)
+
+        for split, split_length in zip(splits, splits_lengths):
+            if split_length > self._chunk_size:
+                if current_splits:
+                    final_chunks.extend(
+                        self._merge_splits(current_splits, separator_for_merge, current_lengths)
+                    )
+                    current_splits = []
+                    current_lengths = []
+
+                final_chunks.extend(self.recursive_split_text(split))
             else:
-                final_chunks.append(chunk)
+                current_splits.append(split)
+                current_lengths.append(split_length)
+
+        if current_splits:
+            final_chunks.extend(
+                self._merge_splits(current_splits, separator_for_merge, current_lengths)
+            )
 
         return final_chunks
 

--- a/api/tests/unit_tests/core/rag/test_fixed_text_splitter.py
+++ b/api/tests/unit_tests/core/rag/test_fixed_text_splitter.py
@@ -1,0 +1,29 @@
+from core.rag.splitter.fixed_text_splitter import FixedRecursiveCharacterTextSplitter
+
+
+def test_fixed_splitter_groups_short_lines_until_chunk_size() -> None:
+    splitter = FixedRecursiveCharacterTextSplitter(
+        chunk_size=25,
+        chunk_overlap=0,
+        fixed_separator="\n",
+    )
+
+    text = "Pain!\nSo painful!\nMy head hurts so much!"
+
+    chunks = splitter.split_text(text)
+
+    assert chunks == ["Pain!\nSo painful!", "My head hurts so much!"]
+
+
+def test_fixed_splitter_preserves_consecutive_separators() -> None:
+    splitter = FixedRecursiveCharacterTextSplitter(
+        chunk_size=20,
+        chunk_overlap=0,
+        fixed_separator="\n",
+    )
+
+    text = "A\n\nB"
+
+    chunks = splitter.split_text(text)
+
+    assert chunks == ["A\n\nB"]


### PR DESCRIPTION
## Summary
- update `FixedRecursiveCharacterTextSplitter` to merge fixed-separator splits up to the configured chunk size before emitting chunks, falling back to recursive splitting only for oversized segments
- add unit tests covering buffer-first grouping of newline-delimited text and preservation of consecutive separators

## Testing
- uv run --project api pytest --override-ini addopts='' api/tests/unit_tests/core/rag/test_fixed_text_splitter.py

------
https://chatgpt.com/codex/tasks/task_b_68c9285eb51883298e64ce1fde044f6c